### PR TITLE
Add proper t.plan and err handling to tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -5,16 +5,14 @@ var globs = ['fixture/one.txt', 'fixture/t*.txt', 'fixture/**/*.wild']
 var options = {cwd: __dirname}
 
 test('deglob async', function (t) {
+  t.plan(1)
   deglob(globs, options, function (err, files) {
-    t.plan(1)
-    if (err) t.fail(err)
+    if (err) return t.end(err)
     t.deepEqual(files, allFiles)
-    t.end()
   })
 })
 
 test('deglob sync', function (t) {
-  t.plan(1)
   var files = deglob.sync(globs, options)
   t.deepEqual(files, allFiles)
   t.end()


### PR DESCRIPTION
Plan is useful for async tests, unnecessary boilerplate for sync ones. Always plan at the top of tests, never inside a callback from your source. When errors happen, you want to end the test and short circuit execution since assertions will fail.
