### PR TITLE
Properly set default for options.cwd

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "array-uniq": "~1.0.2",
     "asyncreduce": "~0.1.4",
-    "glob": "^5.0.10"
+    "glob": "^5.0.10",
+    "xtend": "^4.0.0"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
The way you had things before you would have sometimes returned an absolute path (when `opts.cwd` was passed) and sometimes a relative one (no cwd). 

Also best not to use var names like absolute since it's ambiguous and I'd assume `absolute === path.absolute`. 
